### PR TITLE
Remove deprecated constant, fixes #16

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -29,7 +29,7 @@ $messageproviders = [
     'gradingmessages' => [
         'capability' => 'mod/margic:receivegradingmessages',
         'defaults' => [
-            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
             'email' => MESSAGE_PERMITTED,
         ],
     ],


### PR DESCRIPTION
MESSAGE_DEFAULT_LOGGEDIN and MESSAGE_DEFAULT_LOGGEDOFF are deprecated since Moodle 4.0 (MDL-73284). MESSAGE_DEFAULT_ENABLED replaces them. Presumably removes support for MOODLE<4.0