### PR TITLE
security: Remove RISK_XSS from mod/margic:addentries capability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Changelog ##
 
+- [1.4.1]:
+    - [Security]: Removed the `RISK_XSS` flag from the `mod/margic:addentries` capability. Entry text submitted by participants is always run through `format_text()` with HTML cleaning enabled before it is stored, so participants cannot inject scripts. Moodle therefore no longer shows an XSS warning when assigning this capability to the student role (the `RISK_SPAM` flag is kept).
+    - [Security]: Set the entry editor option `trusttext` to `false`. Entry text is always cleaned, so trusted (unfiltered) text was never honoured for entries anyway; making this explicit ensures the no-XSS guarantee also holds if the cleaning is ever moved to display time.
+
 - [1.4.0]:
     - Migrated the plugin to Bootstrap 5 for compatibility with Moodle 5.0, 5.1 and 5.2.
         - Replaced the deprecated `data-toggle` / `data-target` attributes with their `data-bs-*` equivalents in all mustache templates (thanks to NJahreis for the original fix, #18 / #19).

--- a/classes/local/helper.php
+++ b/classes/local/helper.php
@@ -304,7 +304,7 @@ class helper {
 
         // For the editor.
         $editoroptions = [
-            'trusttext' => true,
+            'trusttext' => false,
             'maxfiles' => EDITOR_UNLIMITED_FILES,
             'maxbytes' => $maxbytes,
             'context' => $context,

--- a/db/access.php
+++ b/db/access.php
@@ -59,7 +59,7 @@ $capabilities = [
     ],
 
     'mod/margic:addentries' => [
-        'riskbitmask' => RISK_XSS | RISK_SPAM,
+        'riskbitmask' => RISK_SPAM,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
         'archetypes' => [

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_margic';
-$plugin->release = '1.4.0';        // User-friendly version number.
-$plugin->version = 2026060701;        // The current module version (Date: YYYYMMDDXX).
+$plugin->release = '1.4.1';        // User-friendly version number.
+$plugin->version = 2026060703;        // The current module version (Date: YYYYMMDDXX).
 $plugin->requires = 2025041400;      // Requires Moodle 5.0 (Bootstrap 5).
 $plugin->supported = [500, 502];     // Supported from Moodle 5.0 to 5.2.
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
## Summary

Removes the `RISK_XSS` flag from the `mod/margic:addentries` capability so Moodle no longer shows an XSS warning when this capability is assigned to the student role.

Entry text submitted by participants is always run through `format_text()` with HTML cleaning enabled before it is stored (`edit.php:220`), so participants cannot inject scripts. The `RISK_XSS` flag was purely advisory; the actual cleaning is unaffected. `RISK_SPAM` is kept. This matches the behaviour of comparable plugins such as `mod_pdfannotator`.

Additionally sets the entry editor option `trusttext` to `false`: trusted (unfiltered) text was never honoured for entries anyway, and making this explicit keeps the no-XSS guarantee robust if cleaning is ever moved to display time.

## Changes
- `db/access.php` — `mod/margic:addentries`: `RISK_XSS | RISK_SPAM` → `RISK_SPAM`
- `classes/local/helper.php` — entry editor option `trusttext`: `true` → `false`
- `version.php` — version bump, release `1.4.1`
- `CHANGES.md` — `[1.4.1]` security entries

## Notes
- The riskbitmask change is applied automatically by Moodle's `update_capabilities()` on upgrade (version bump included); no `db/upgrade.php` step needed.
- CI checks (codechecker/phpdoc) were not run locally (no moodle-plugin-ci environment); changes are declarative/config only.